### PR TITLE
Set owner-only permissions for ~/.H2Orestart and temp files

### DIFF
--- a/source/ebandal/libreoffice/comp/H2OrestartImpl.java
+++ b/source/ebandal/libreoffice/comp/H2OrestartImpl.java
@@ -59,6 +59,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -262,7 +263,8 @@ public final class H2OrestartImpl extends WeakBase implements ebandal.libreoffic
             }
         }
         try {
-            Files.createDirectories(Paths.get(System.getProperty("user.home"),".H2Orestart"));
+            Files.createDirectories(Paths.get(System.getProperty("user.home"),".H2Orestart"),
+                                    PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
             // "%h" the value of the "user.home" system property
             FileHandler fileHandler = new FileHandler("%h/.H2Orestart/import_%g.log", 4194304, 10, false);
             fileHandler.setLevel(Level.INFO);
@@ -347,8 +349,9 @@ public final class H2OrestartImpl extends WeakBase implements ebandal.libreoffic
                         byte[] buf = new byte[4096];
                         XInputStream xinput = UnoRuntime.queryInterface(XInputStream.class, args[i][j].Value);
                         try {
-                            File tmpFile = File.createTempFile("H2O_TMP_", null, 
-                                                                Paths.get(System.getProperty("user.home"),".H2Orestart").toFile());
+                            File tmpFile = Files.createTempFile(Paths.get(System.getProperty("user.home"),".H2Orestart"),
+                                                                "H2O_TMP_", null,
+                                                                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------"))).toFile();
                             tmpFile.deleteOnExit();
                             tmpFilePath = tmpFile.toString();
                             try (FileOutputStream fos = new FileOutputStream(tmpFile);


### PR DESCRIPTION
* Use 700 (rwx------) for ~/.H2Orestart directory.

* Use 600 (rw-------) for temporary files under it.

https://github.com/ebandal/H2Orestart/issues/19

----
퍼미션 설정입니다. 개별 로그파일(.log)의 경우에는 설정할 방법이 마땅치 않은데요. 디렉터리 퍼미션에서 막혀 있어 일단 다른 유저가 읽을 수 없으니 될 것 같습니다.
